### PR TITLE
Add rubocop file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+Documentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded


### PR DESCRIPTION
This PR adds a `rubocop` file with the following rules:

```
Documentation:
  Enabled: false

Style/EmptyMethod:
  EnforcedStyle: expanded
```

- First rule would be covered by Rails through the command `#:nodoc:`, anyway in case we have to make a Ruby file that doesn't inherit from Rails, we'll be covered.
- Second rule is a nice to have, to get an auto expanded method when we define it.

Expanded
---
```
def stuff

end
```

Not-Expanded
---
```
def stuff; end
```